### PR TITLE
Don't use preserve-order parameter for fs images.

### DIFF
--- a/mic/imager/fs.py
+++ b/mic/imager/fs.py
@@ -79,7 +79,6 @@ class FsImageCreator(BaseImageCreator):
             tar = find_binary_path('tar')
             tar_cmdline = [tar, "--numeric-owner",
                                 "--preserve-permissions",
-                                "--preserve-order",
                                 "--one-file-system",
                                 "--directory",
                                 self._instroot]


### PR DESCRIPTION
Preserve-order parameter is conflicting with create a new archive
on tar 1.27 and newer versions. This option should not be needed
on modern computer systems.