### PR TITLE
[mic] Don't use obsolete string.join(). Fixes JB#51348

### DIFF
--- a/mic/kickstart/__init__.py
+++ b/mic/kickstart/__init__.py
@@ -22,7 +22,6 @@ import os, sys, re
 import shutil
 import subprocess
 import time
-import string
 
 from mic import msger
 from mic.utils import errors, misc, runner, fs_related as fs
@@ -428,7 +427,7 @@ class UserConfig(KickstartConfig):
     def addUser(self, userconfig):
         args = [ "/usr/sbin/useradd" ]
         if userconfig.groups:
-            args += [ "--groups", string.join(userconfig.groups, ",") ]
+            args += [ "--groups", ",".join(userconfig.groups) ]
         if userconfig.name:
             args.append(userconfig.name)
             try:


### PR DESCRIPTION
Since Python 3 there is no `string.join()` method in `string` module, and such constructions must be replaced with `"".join()`.