### PR TITLE
[mic] Run fsck after using tunefs on ext format loop images. JB#58901

### DIFF
--- a/mic/imager/loop.py
+++ b/mic/imager/loop.py
@@ -416,6 +416,7 @@ class LoopImageCreator(BaseImageCreator):
             if item['fstype'] == "ext4":
                 runner.show('/sbin/tune2fs -O ^huge_file,extents,uninit_bg %s '
                             % imgfile)
+                runner.show('/sbin/e2fsck -f -y %s' % imgfile)
             if self.compress_image:
                 misc.compressing(imgfile, self.compress_image)
 


### PR DESCRIPTION
tunefs asks to run fsck after tunefs was applied on file systems:

``` irc-log
Verbose[12/20 12:12:35] : running command: "/sbin/tune2fs -O ^huge_file,extents,uninit_bg /var/tmp/mic/imgcreate-arwktabf/tmp-e4zx7mj0/home.img ", with output::
  +----------------
  | tune2fs 1.46.5 (30-Dec-2021)
  |
  | Please run e2fsck -f on the filesystem.
  +----------------
```