### PR TITLE
[fs] Preserve extended attributes in rootfs tar archive. OMP#OS-14810

### DIFF
--- a/mic/imager/fs.py
+++ b/mic/imager/fs.py
@@ -80,6 +80,7 @@ class FsImageCreator(BaseImageCreator):
             tar_cmdline = [tar, "--numeric-owner",
                                 "--preserve-permissions",
                                 "--one-file-system",
+                                "--xattrs",
                                 "--directory",
                                 self._instroot]
             for ignore_entry in ignores:


### PR DESCRIPTION
Files on rootfs should preserve extended attributes. Following attributes are used at least:
- security capabilities (/usr/bin/instance-unique-device-id)
- security IMA attributes

To unpack rootfs archive following archive should be used: sudo tar --xattrs --xattrs-include='*' -xf latest--qmp-m1-n-ip-armv7hl.tar.bz2